### PR TITLE
Implement complete RR log support

### DIFF
--- a/src/focaccia/deterministic.py
+++ b/src/focaccia/deterministic.py
@@ -491,7 +491,7 @@ class DeterministicLog:
                 return regs['pc'], regs
             raise NotImplementedError(f'Unable to parse registers for architecture {arch}')
 
-        def parse_memory_writes(event: Frame, reader: io.RawIOBase):
+        def parse_memory_writes(event: Frame, reader: io.RawIOBase) -> list[MemoryWrite]:
             writes = []
             for raw_write in event.memWrites:
                 # Skip memory writes with 0 bytes


### PR DESCRIPTION
This PR completes the implementation of RR log parsing needed for Focaccia. Most of the log data can now be read by Focaccia, including MMaps and Tasks. The missing pieces of data are not currently necessary but they can be added on a per-need basis.